### PR TITLE
adds online count to lfm toolbar

### DIFF
--- a/src/components/app/NavMenu.tsx
+++ b/src/components/app/NavMenu.tsx
@@ -38,7 +38,7 @@ const NavMenu = () => {
             </Link>
             <Link
                 to="/servers"
-                className={`nav-item ${location.pathname.startsWith("/servers") ? "active" : ""}`}
+                className={`nav-item hide-on-small-mobile ${location.pathname.startsWith("/servers") ? "active" : ""}`}
                 disabled
             >
                 <ServersSVG className="nav-icon" />

--- a/src/components/global/ColoredText.tsx
+++ b/src/components/global/ColoredText.tsx
@@ -1,19 +1,24 @@
 import React from "react"
 
-interface Props {
-    color?: "red" | "green" | "blue" | "orange" | "secondary" | "default"
+type Color = "red" | "green" | "blue" | "orange" | "secondary" | "default"
+
+interface Props extends React.HTMLAttributes<HTMLSpanElement> {
+    color?: Color
     children: React.ReactNode
+    className?: string
 }
 
-const ColoredText = ({ color = "default", children }: Props) => {
-    const getTextClass = () => {
-        if (color === "default") {
-            return ""
-        } else {
-            return color + "-text"
-        }
-    }
-    return <span className={getTextClass()}>{children}</span>
+const ColoredText = ({
+    color = "default",
+    children,
+    className = "",
+    ...rest
+}: Props) => {
+    const colorClass = color === "default" ? "" : `${color}-text`
+    return (
+        <span className={`${colorClass} ${className}`.trim()} {...rest}>
+            {children}
+        </span>
+    )
 }
-
 export default ColoredText

--- a/src/components/global/GenericToolbar.tsx
+++ b/src/components/global/GenericToolbar.tsx
@@ -15,6 +15,7 @@ import "./GenericToolbar.css"
 import { toSentenceCase } from "../../utils/stringUtils.ts"
 import Button from "./Button.tsx"
 import Stack from "./Stack.tsx"
+import ColoredText from "./ColoredText.tsx"
 
 interface Props {
     handleReload: () => void
@@ -25,6 +26,7 @@ interface Props {
     serverName: string
     isSecondaryPanel?: boolean
     handleScreenshot?: () => void
+    characterCount?: number
 }
 
 const GenericToolbar = ({
@@ -36,6 +38,7 @@ const GenericToolbar = ({
     serverName = "",
     isSecondaryPanel,
     handleScreenshot = () => {},
+    characterCount,
 }: Props) => {
     const { isFullScreen, setIsFullScreen } = useThemeContext()
     const [canManuallyReload, setCanManuallyReload] = useState(true)
@@ -65,20 +68,35 @@ const GenericToolbar = ({
                 </button>
             ) : (
                 <Link to={linkDestination} className="item">
-                    <MenuSVG className="icon" />
-                    <span>
-                        {toSentenceCase(serverName)}
-                        {VIP_SERVER_NAMES_LOWER.includes(serverName) && (
-                            <>
-                                {" "}
+                    <Stack direction="row" gap="5px" align="center">
+                        <MenuSVG className="icon" />
+                        <Stack direction="row" gap="5px" align="center">
+                            {toSentenceCase(serverName)}
+                            {VIP_SERVER_NAMES_LOWER.includes(serverName) && (
                                 <Badge
                                     text="VIP"
                                     size="small"
                                     backgroundColor="var(--orange4)"
                                 />
-                            </>
+                            )}
+                        </Stack>
+                        {characterCount != undefined && (
+                            <ColoredText
+                                color="secondary"
+                                className="hide-on-smallish-mobile"
+                            >
+                                &bull;
+                            </ColoredText>
                         )}
-                    </span>
+                        {characterCount != undefined && (
+                            <ColoredText
+                                color="secondary"
+                                className="hide-on-smallish-mobile"
+                            >
+                                {characterCount} online
+                            </ColoredText>
+                        )}
+                    </Stack>
                 </Link>
             )}
             <Button

--- a/src/components/grouping/LfmCanvasContainer.tsx
+++ b/src/components/grouping/LfmCanvasContainer.tsx
@@ -168,6 +168,10 @@ const GroupingContainer = ({
         [serverInfoData, serverInfoState, refreshInterval, isServerOffline]
     )
 
+    const characterCount = useMemo<number>(() => {
+        return serverInfoData?.[serverName]?.character_count || 0
+    }, [serverInfoData, serverName])
+
     // filter and sort the lfms
     const filteredLfms = useMemo(() => {
         if (!lfmData?.data)
@@ -426,6 +430,7 @@ const GroupingContainer = ({
                         isSecondaryPanel={isSecondaryPanel}
                         handleClosePanel={handleClosePanel}
                         handleScreenshot={handleScreenshot}
+                        characterCount={characterCount}
                     />
                     <LfmCanvas
                         serverName={serverName}

--- a/src/components/grouping/LfmToolbar.tsx
+++ b/src/components/grouping/LfmToolbar.tsx
@@ -31,6 +31,7 @@ interface Props {
     isSecondaryPanel?: boolean
     handleClosePanel?: () => void
     handleScreenshot?: () => void
+    characterCount?: number
 }
 
 const LfmToolbar = ({
@@ -39,6 +40,7 @@ const LfmToolbar = ({
     isSecondaryPanel,
     handleClosePanel = () => {},
     handleScreenshot = () => {},
+    characterCount,
 }: Props) => {
     const {
         minLevel,
@@ -549,6 +551,7 @@ const LfmToolbar = ({
                 linkDestination="/grouping"
                 isSecondaryPanel={isSecondaryPanel}
                 handleScreenshot={handleScreenshot}
+                characterCount={characterCount}
             />
         </>
     )

--- a/src/components/who/WhoCanvasContainer.tsx
+++ b/src/components/who/WhoCanvasContainer.tsx
@@ -12,9 +12,9 @@ import { LoadingState } from "../../models/Api.ts"
 import {
     LiveDataHaultedPageMessage,
     ServerOfflineMessage,
+    StaleDataPageMessage,
 } from "../global/CommonMessages.tsx"
 import WhoToolbar from "./WhoToolbar.tsx"
-import { MAXIMUM_CHARACTER_COUNT } from "../../constants/whoPanel.ts"
 import { useAreaContext } from "../../contexts/AreaContext.tsx"
 import useGetRegisteredCharacters from "../../hooks/useGetRegisteredCharacters.ts"
 import useGetFriends from "../../hooks/useGetFriends.ts"
@@ -83,6 +83,18 @@ const WhoContainer = ({
             serverInfoState === LoadingState.Loaded &&
             !serverInfoData?.[serverName]?.is_online,
         [serverInfoData, serverName]
+    )
+
+    const isDataStale = useMemo<boolean>(
+        () =>
+            !!serverInfoData?.[serverName] &&
+            !isServerOffline &&
+            serverInfoState === LoadingState.Loaded &&
+            serverInfoData?.[serverName]?.last_data_fetch &&
+            Date.now() -
+                new Date(serverInfoData[serverName].last_data_fetch).getTime() >
+                5 * 60 * 1000,
+        [serverInfoData, serverInfoState, isServerOffline]
     )
 
     var handleScreenshot = function () {
@@ -331,6 +343,7 @@ const WhoContainer = ({
             {characterState === LoadingState.Haulted && (
                 <LiveDataHaultedPageMessage />
             )}
+            {isDataStale && <StaleDataPageMessage />}
             {!isServerOffline || ignoreServerDown ? (
                 <>
                     <WhoToolbar

--- a/src/index.css
+++ b/src/index.css
@@ -341,6 +341,14 @@ table tbody tr:last-of-type {
     }
 }
 
+/* small-ish mobile */
+@media (max-width: 400px) {
+    .hide-on-smallish-mobile {
+        display: none !important;
+    }
+}
+    
+
 /* small mobile */
 @media (max-width: 300px) {
     html {


### PR DESCRIPTION
From user feedback:

> Can we have live pop graph as a second panel in the lfm viewer? Or a live pop count osmewhere on the lfm page