### PR TITLE
owned content, hide full groups

### DIFF
--- a/src/browserRouter.tsx
+++ b/src/browserRouter.tsx
@@ -56,6 +56,9 @@ const Ignores = lazy(() =>
 const Guilds = lazy(() =>
     lazyRetry(() => import("./components/guilds/Guilds.tsx"))
 )
+const OwnedContent = lazy(() =>
+    lazyRetry(() => import("./components/owned-content/OwnedContent.tsx"))
+)
 // const Trends = lazy(() => lazyRetry(() => import("./components/trends/Trends.tsx")))
 // const Quests = lazy(() => lazyRetry(() => import("./components/quests/Quests.tsx")))
 
@@ -75,6 +78,14 @@ export default createBrowserRouter(
                 }
             />
             {/* <Route path="/activity" element={<Activity />} /> */}
+            <Route
+                path="/owned-content"
+                element={
+                    <GroupingDataProvider>
+                        <OwnedContent />
+                    </GroupingDataProvider>
+                }
+            />
             <Route
                 path="/grouping"
                 element={

--- a/src/components/global/Checkbox.css
+++ b/src/components/global/Checkbox.css
@@ -5,6 +5,10 @@
     gap: 5px;
     font-size: 1rem;
     margin: 0;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
 }
 
 .checkbox-input {

--- a/src/components/grouping/LfmCanvasContainer.tsx
+++ b/src/components/grouping/LfmCanvasContainer.tsx
@@ -58,6 +58,10 @@ const GroupingContainer = ({
         hideGroupsContainingIgnoredCharacters,
         hideAllLevelGroups,
         onlyShowRaids,
+        hideContentIDontOwn,
+        indicateContentIDontOwn,
+        ownedContent,
+        hideFullGroups,
     } = useLfmContext()
     const [ignoreServerDown, setIgnoreServerDown] = useState<boolean>(false)
     const { friends: friendCharacters } = useGetFriends()
@@ -306,6 +310,31 @@ const GroupingContainer = ({
                     }
                 }
 
+                let owned: boolean = true
+                if (ownedContent != undefined) {
+                    if (
+                        selectedQuest &&
+                        selectedQuest.required_adventure_pack
+                    ) {
+                        if (
+                            !ownedContent.includes(
+                                selectedQuest.required_adventure_pack
+                            )
+                        ) {
+                            owned = false
+                        }
+                    }
+                }
+
+                let isFull: boolean = false
+                if (
+                    lfm.members?.length === 5 ||
+                    (lfm.members?.length === 11 &&
+                        selectedQuest?.group_size !== "Raid")
+                ) {
+                    isFull = true
+                }
+
                 return {
                     ...lfm,
                     quest: selectedQuest,
@@ -316,6 +345,8 @@ const GroupingContainer = ({
                         isPostedByFriend,
                         includesFriend,
                         raidActivity: activity,
+                        owned,
+                        isFull,
                     },
                 }
             })
@@ -325,6 +356,14 @@ const GroupingContainer = ({
                 if (onlyShowRaids) {
                     if (lfm.quest?.group_size !== "Raid") return false
                 }
+                if (
+                    hideContentIDontOwn &&
+                    lfm.quest != undefined &&
+                    lfm.quest.required_adventure_pack != undefined &&
+                    !ownedContent?.includes(lfm.quest.required_adventure_pack)
+                )
+                    return false
+                if (hideFullGroups && lfm.metadata.isFull) return false
                 return true
             })
             .sort((lfmA, lfmB) => {
@@ -394,6 +433,9 @@ const GroupingContainer = ({
         onlyShowRaids,
         hideGroupsPostedByIgnoredCharacters,
         hideGroupsContainingIgnoredCharacters,
+        hideContentIDontOwn,
+        indicateContentIDontOwn,
+        hideFullGroups,
     ])
 
     return (

--- a/src/components/grouping/LfmCanvasContainer.tsx
+++ b/src/components/grouping/LfmCanvasContainer.tsx
@@ -24,7 +24,12 @@ import useGetIgnores from "../../hooks/useGetIgnores.ts"
 import logMessage from "../../utils/logUtils.ts"
 import { useQuestContext } from "../../contexts/QuestContext.tsx"
 import Stack from "../global/Stack.tsx"
-import { MAX_LEVEL, MIN_LEVEL } from "../../constants/game.ts"
+import {
+    MAX_LEVEL,
+    MAX_PARTY_SIZE,
+    MAX_RAID_SIZE,
+    MIN_LEVEL,
+} from "../../constants/game.ts"
 
 interface Props {
     serverName: string
@@ -328,8 +333,8 @@ const GroupingContainer = ({
 
                 let isFull: boolean = false
                 if (
-                    lfm.members?.length === 5 ||
-                    (lfm.members?.length === 11 &&
+                    lfm.members?.length === MAX_PARTY_SIZE - 1 ||
+                    (lfm.members?.length === MAX_RAID_SIZE - 1 &&
                         selectedQuest?.group_size !== "Raid")
                 ) {
                     isFull = true
@@ -416,12 +421,12 @@ const GroupingContainer = ({
             excludedLfmCount: lfms?.length - processedLfms?.length,
         }
     }, [
+        serverName,
         lfmData,
         sortBy,
         minLevelFilter,
         showNotEligible,
         maxLevelFilter,
-        serverName,
         filterByMyCharacters,
         registeredCharacters,
         trackedCharacterIds,
@@ -436,6 +441,7 @@ const GroupingContainer = ({
         hideContentIDontOwn,
         indicateContentIDontOwn,
         hideFullGroups,
+        ownedContent,
     ])
 
     return (

--- a/src/components/grouping/LfmCanvasContainer.tsx
+++ b/src/components/grouping/LfmCanvasContainer.tsx
@@ -333,9 +333,9 @@ const GroupingContainer = ({
 
                 let isFull: boolean = false
                 if (
-                    lfm.members?.length === MAX_PARTY_SIZE - 1 ||
-                    (lfm.members?.length === MAX_RAID_SIZE - 1 &&
-                        selectedQuest?.group_size !== "Raid")
+                    (lfm.members?.length === MAX_PARTY_SIZE - 1 &&
+                        selectedQuest?.group_size !== "Raid") ||
+                    lfm.members?.length === MAX_RAID_SIZE - 1
                 ) {
                     isFull = true
                 }

--- a/src/components/grouping/LfmToolbar.tsx
+++ b/src/components/grouping/LfmToolbar.tsx
@@ -99,6 +99,12 @@ const LfmToolbar = ({
         setShowEligibilityDividers,
         onlyShowRaids,
         setOnlyShowRaids,
+        hideContentIDontOwn,
+        setHideContentIDontOwn,
+        indicateContentIDontOwn,
+        setIndicateContentIDontOwn,
+        hideFullGroups,
+        setHideFullGroups,
     } = useLfmContext()
     const { reloadQuests } = useQuestContext()
     const { reloadAreas } = useAreaContext()
@@ -262,6 +268,33 @@ const LfmToolbar = ({
                     >
                         Show groups I'm not eligible for
                     </Checkbox>
+                    <FeaturedItem calloutId="hide-content-i-dont-own">
+                        <Checkbox
+                            checked={hideContentIDontOwn}
+                            onChange={(e) =>
+                                setHideContentIDontOwn(e.target.checked)
+                            }
+                        >
+                            Hide content I don't own
+                        </Checkbox>
+                    </FeaturedItem>
+                    <FeaturedItem calloutId="indicate-content-i-dont-own">
+                        <Checkbox
+                            checked={indicateContentIDontOwn}
+                            onChange={(e) =>
+                                setIndicateContentIDontOwn(e.target.checked)
+                            }
+                        >
+                            Indicate content I don't own
+                        </Checkbox>
+                    </FeaturedItem>
+                    <div
+                        style={{
+                            marginLeft: "20px",
+                        }}
+                    >
+                        <Link to="/owned-content">Content list</Link>
+                    </div>
                     <Stack width="100%" justify="flex-end">
                         <Button
                             onClick={handleOpenResetFiltersModal}
@@ -351,6 +384,16 @@ const LfmToolbar = ({
                             }
                         >
                             Hide groups posting for levels 1-34
+                        </Checkbox>
+                    </FeaturedItem>
+                    <FeaturedItem calloutId="hide-full-groups">
+                        <Checkbox
+                            checked={hideFullGroups}
+                            onChange={(e) =>
+                                setHideFullGroups(e.target.checked)
+                            }
+                        >
+                            Hide groups that are likely full
                         </Checkbox>
                     </FeaturedItem>
                     <FeaturedItem calloutId="grouping-eligibility-dividers">

--- a/src/components/owned-content/OwnedContent.css
+++ b/src/components/owned-content/OwnedContent.css
@@ -1,0 +1,15 @@
+/* .filter-section {
+    margin-left: 5px;
+    padding-left: 10px;
+    border-left: 2px solid var(--secondary-text);
+} */
+
+.multi-select {
+    border-left: none;
+    padding: 10px 10px;
+    box-sizing: border-box;
+    overflow-y: auto;
+    max-height: 240px;
+    width: 100%;
+    box-shadow: inset 0 0 20px var(--shadow);
+}

--- a/src/components/owned-content/OwnedContent.tsx
+++ b/src/components/owned-content/OwnedContent.tsx
@@ -1,0 +1,208 @@
+import React, { useEffect, useMemo, useState } from "react"
+import "./OwnedContent.css"
+import Page from "../global/Page.tsx"
+import {
+    ContentCluster,
+    ContentClusterGroup,
+} from "../global/ContentCluster.tsx"
+import { useQuestContext } from "../../contexts/QuestContext.tsx"
+import Checkbox from "../global/Checkbox.tsx"
+import Stack from "../global/Stack.tsx"
+import Button from "../global/Button"
+import { useLfmContext } from "../../contexts/LfmContext.tsx"
+import ColoredText from "../global/ColoredText.tsx"
+import Spacer from "../global/Spacer.tsx"
+import Link from "../global/Link.tsx"
+import NavCardCluster from "../global/NavCardCluster.tsx"
+import NavigationCard from "../global/NavigationCard.tsx"
+
+const OwnedContent = () => {
+    const { quests } = useQuestContext()
+    const { ownedContent, setOwnedContent } = useLfmContext()
+
+    const [contentFilterText, setContentFilterText] = useState<string>("")
+
+    const handleContentSelection = (
+        e: React.ChangeEvent<HTMLInputElement>,
+        adventurePack: string
+    ) => {
+        const filteredContent =
+            ownedContent?.filter((i) => i !== adventurePack) || []
+        if (e.target.checked) {
+            setOwnedContent([...filteredContent, adventurePack])
+        } else {
+            setOwnedContent(filteredContent)
+        }
+    }
+
+    const adventurePacks: string[] = useMemo(() => {
+        const packs: Set<string> = new Set<string>()
+        Object.values(quests).forEach((quest) => {
+            if (
+                quest.required_adventure_pack != undefined &&
+                quest.required_adventure_pack.trim() !== ""
+            ) {
+                packs.add(quest.required_adventure_pack)
+            }
+        })
+        return Array.from(packs).sort((a, b) =>
+            (a || "").localeCompare(b || "")
+        )
+    }, [quests])
+
+    const handleSelectAll = () => {
+        if (!contentFilterText) {
+            setOwnedContent(adventurePacks)
+        } else {
+            const tempContent = [
+                ...ownedContent,
+                ...adventurePacks.filter((adventurePack) => {
+                    return adventurePack
+                        .toLowerCase()
+                        .includes(contentFilterText.toLowerCase())
+                }),
+            ]
+            setOwnedContent(Array.from(new Set(tempContent)))
+        }
+    }
+
+    const handleDeselectAll = () => {
+        if (!contentFilterText) {
+            setOwnedContent([])
+        } else {
+            setOwnedContent([
+                ...ownedContent.filter((adventurePack) => {
+                    return !adventurePack
+                        .toLowerCase()
+                        .includes(contentFilterText.toLowerCase())
+                }),
+            ])
+        }
+    }
+
+    const filteredContent = useMemo(
+        () =>
+            Array.from(adventurePacks).filter((adventurePack) => {
+                if (!contentFilterText) return true
+                return adventurePack
+                    .toLowerCase()
+                    .includes(contentFilterText.toLowerCase())
+            }),
+        [adventurePacks, contentFilterText]
+    )
+
+    return (
+        <Page
+            title="Owned Content"
+            description="Specify the adventure packs and expansions that you own to better filter the LFM Viewed."
+        >
+            <ContentClusterGroup>
+                <ContentCluster
+                    title="Adventure Packs and Expansions"
+                    subtitle="Specify the content that you own. You can choose to filter the LFM Viewed based on your selection."
+                >
+                    <Stack direction="column" gap="10px">
+                        <Stack
+                            direction="row"
+                            gap="10px"
+                            width="100%"
+                            align="flex-end"
+                        >
+                            <Stack
+                                direction="column"
+                                gap="2px"
+                                className="full-width-on-mobile"
+                            >
+                                <label
+                                    htmlFor="content-filter-input"
+                                    style={{
+                                        color: "var(--secondary-text)",
+                                        fontWeight: "bolder",
+                                    }}
+                                >
+                                    Filter
+                                </label>
+                                <input
+                                    id="content-filter-input"
+                                    value={contentFilterText}
+                                    onChange={(e) =>
+                                        setContentFilterText(e.target.value)
+                                    }
+                                    style={{
+                                        width: "100%",
+                                        boxSizing: "border-box",
+                                    }}
+                                />
+                            </Stack>
+                            <Stack
+                                gap="5px"
+                                style={{
+                                    marginLeft: "auto",
+                                }}
+                            >
+                                <Button
+                                    type="secondary"
+                                    onClick={() => handleSelectAll()}
+                                    small
+                                    style={{
+                                        width: "max-content",
+                                    }}
+                                >
+                                    Select {contentFilterText ? "Shown" : "All"}
+                                </Button>
+                                <Button
+                                    type="secondary"
+                                    onClick={() => handleDeselectAll()}
+                                    small
+                                    style={{
+                                        width: "max-content",
+                                    }}
+                                >
+                                    Deselect{" "}
+                                    {contentFilterText ? "Shown" : "All"}
+                                </Button>
+                            </Stack>
+                        </Stack>
+                        <div className="multi-select">
+                            <Stack direction="column" gap="3px">
+                                {filteredContent.map(
+                                    (adventurePack: string) => (
+                                        <Checkbox
+                                            checked={ownedContent?.includes(
+                                                adventurePack
+                                            )}
+                                            onChange={(e) =>
+                                                handleContentSelection(
+                                                    e,
+                                                    adventurePack
+                                                )
+                                            }
+                                        >
+                                            {adventurePack}
+                                        </Checkbox>
+                                    )
+                                )}
+                                {(!filteredContent ||
+                                    filteredContent.length === 0) && (
+                                    <span>There's nothing here</span>
+                                )}
+                            </Stack>
+                        </div>
+                    </Stack>
+                    <Spacer size="15px" />
+                    <ColoredText color="secondary">
+                        Missing content? Other issues? Please{" "}
+                        <Link to="/feedback">let me know</Link>.
+                    </ColoredText>
+                </ContentCluster>
+                <ContentCluster title="See Also...">
+                    <NavCardCluster>
+                        <NavigationCard type="grouping" />
+                    </NavCardCluster>
+                </ContentCluster>
+            </ContentClusterGroup>
+        </Page>
+    )
+}
+
+export default OwnedContent

--- a/src/components/owned-content/OwnedContent.tsx
+++ b/src/components/owned-content/OwnedContent.tsx
@@ -36,6 +36,9 @@ const OwnedContent = () => {
     }
 
     const adventurePacks: string[] = useMemo(() => {
+        if (!quests) return []
+        if (Object.keys(quests).length === 0) return []
+
         const packs: Set<string> = new Set<string>()
         Object.values(quests).forEach((quest) => {
             if (
@@ -55,7 +58,7 @@ const OwnedContent = () => {
             setOwnedContent(adventurePacks)
         } else {
             const tempContent = [
-                ...ownedContent,
+                ...(ownedContent || []),
                 ...adventurePacks.filter((adventurePack) => {
                     return adventurePack
                         .toLowerCase()
@@ -71,7 +74,7 @@ const OwnedContent = () => {
             setOwnedContent([])
         } else {
             setOwnedContent([
-                ...ownedContent.filter((adventurePack) => {
+                ...(ownedContent || []).filter((adventurePack) => {
                     return !adventurePack
                         .toLowerCase()
                         .includes(contentFilterText.toLowerCase())

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -96,6 +96,12 @@ const bannerRouteMapping = {
         showButtons: true,
         hideSuggestionButton: true,
     },
+    "owned-content": {
+        title: "Content",
+        subtitle: "Set Owned Content for Eligibility Filtering",
+        miniature: true,
+        showButtons: false,
+    },
 }
 
 export { bannerRouteMapping }

--- a/src/constants/game.ts
+++ b/src/constants/game.ts
@@ -3,6 +3,8 @@ const RANSACK_THRESHOLD = 7
 const RAID_TIMER_MILLIS = 66 * 60 * 60 * 1000
 const MIN_LEVEL = 1
 const MAX_LEVEL = 34
+const MAX_PARTY_SIZE = 6
+const MAX_RAID_SIZE = 12
 
 const CLASS_LIST = [
     "Barbarian",
@@ -32,4 +34,6 @@ export {
     CLASS_LIST,
     CLASS_LIST_LOWER,
     RAID_TIMER_MILLIS,
+    MAX_PARTY_SIZE,
+    MAX_RAID_SIZE,
 }

--- a/src/constants/lfmPanel.ts
+++ b/src/constants/lfmPanel.ts
@@ -80,6 +80,7 @@ const LFM_COLORS = {
     SECONDARY_TEXT: "#B6B193",
     GUESS_TEXT: "#D3F6F6",
     ELIGIBILITY_DIVIDER: "#f6e8d3ff",
+    NOT_OWNED: "#ff5555",
 }
 
 const OVERLAY_COLORS = {

--- a/src/contexts/LfmContext.tsx
+++ b/src/contexts/LfmContext.tsx
@@ -88,6 +88,14 @@ interface LfmContextProps {
     setShowEligibilityDividers: (value: boolean) => void
     onlyShowRaids: boolean
     setOnlyShowRaids: (value: boolean) => void
+    hideContentIDontOwn: boolean
+    setHideContentIDontOwn: (value: boolean) => void
+    indicateContentIDontOwn: boolean
+    setIndicateContentIDontOwn: (value: boolean) => void
+    ownedContent: string[] | null
+    setOwnedContent: (value: string[]) => void
+    hideFullGroups: boolean
+    setHideFullGroups: (value: boolean) => void
     resetFilterSettings: () => void
     resetDisplaySettings: () => void
     resetToolSettings: () => void
@@ -117,6 +125,11 @@ export const LfmProvider = ({ children }: { children: ReactNode }) => {
     const [filterByMyCharacters, setFilterByMyCharacters] =
         useState<boolean>(false)
     const [showNotEligible, setShowNotEligible] = useState<boolean>(true)
+    const [hideContentIDontOwn, setHideContentIDontOwn] =
+        useState<boolean>(false)
+    const [indicateContentIDontOwn, setIndicateContentIDontOwn] =
+        useState<boolean>(false)
+    const [ownedContent, setOwnedContent] = useState<string[] | null>(null)
 
     // display:
     const [fontSize, setFontSize] = useState<number>(DEFAULT_BASE_FONT_SIZE)
@@ -138,6 +151,7 @@ export const LfmProvider = ({ children }: { children: ReactNode }) => {
     const [showEligibilityDividers, setShowEligibilityDividers] =
         useState<boolean>(true)
     const [onlyShowRaids, setOnlyShowRaids] = useState<boolean>(false)
+    const [hideFullGroups, setHideFullGroups] = useState<boolean>(false)
 
     // tools:
     const [showRaidTimerIndicator, setShowRaidTimerIndicator] =
@@ -365,6 +379,17 @@ export const LfmProvider = ({ children }: { children: ReactNode }) => {
                 Boolean(settings.filterByMyCharacters ?? false)
             )
             setShowNotEligible(Boolean(settings.showNotEligible ?? true))
+            setHideContentIDontOwn(
+                Boolean(settings.hideContentIDontOwn ?? false)
+            )
+            setIndicateContentIDontOwn(
+                Boolean(settings.indicateContentIDontOwn ?? false)
+            )
+            setOwnedContent(
+                Array.isArray(settings.ownedContent)
+                    ? settings.ownedContent
+                    : []
+            )
 
             const parsedFontSize = parseInt(
                 settings.fontSize ?? String(DEFAULT_BASE_FONT_SIZE)
@@ -426,6 +451,7 @@ export const LfmProvider = ({ children }: { children: ReactNode }) => {
                 Boolean(settings.showEligibilityDividers ?? true)
             )
             setOnlyShowRaids(Boolean(settings.onlyShowRaids ?? false))
+            setHideFullGroups(Boolean(settings.hideFullGroups ?? false))
         } catch (e) {
             logMessage(
                 "Error applying validated settings, falling back to defaults",
@@ -472,6 +498,9 @@ export const LfmProvider = ({ children }: { children: ReactNode }) => {
                 maxLevel,
                 filterByMyCharacters,
                 showNotEligible,
+                hideContentIDontOwn,
+                indicateContentIDontOwn,
+                ownedContent,
                 fontSize,
                 panelWidth,
                 showBoundingBoxes,
@@ -496,6 +525,7 @@ export const LfmProvider = ({ children }: { children: ReactNode }) => {
                 hideAllLevelGroups,
                 showEligibilityDividers,
                 onlyShowRaids,
+                hideFullGroups,
             }
 
             // Validate the settings before saving
@@ -520,6 +550,9 @@ export const LfmProvider = ({ children }: { children: ReactNode }) => {
         maxLevel,
         filterByMyCharacters,
         showNotEligible,
+        hideContentIDontOwn,
+        indicateContentIDontOwn,
+        ownedContent,
         isLoaded,
         fontSize,
         panelWidth,
@@ -545,6 +578,7 @@ export const LfmProvider = ({ children }: { children: ReactNode }) => {
         hideAllLevelGroups,
         showEligibilityDividers,
         onlyShowRaids,
+        hideFullGroups,
     ])
 
     return (
@@ -612,6 +646,14 @@ export const LfmProvider = ({ children }: { children: ReactNode }) => {
                 setShowEligibilityDividers,
                 onlyShowRaids,
                 setOnlyShowRaids,
+                hideContentIDontOwn,
+                setHideContentIDontOwn,
+                indicateContentIDontOwn,
+                setIndicateContentIDontOwn,
+                ownedContent,
+                setOwnedContent,
+                hideFullGroups,
+                setHideFullGroups,
                 resetDisplaySettings,
                 resetFilterSettings,
                 resetToolSettings,

--- a/src/contexts/LfmContext.tsx
+++ b/src/contexts/LfmContext.tsx
@@ -92,7 +92,7 @@ interface LfmContextProps {
     setHideContentIDontOwn: (value: boolean) => void
     indicateContentIDontOwn: boolean
     setIndicateContentIDontOwn: (value: boolean) => void
-    ownedContent: string[] | null
+    ownedContent: string[]
     setOwnedContent: (value: string[]) => void
     hideFullGroups: boolean
     setHideFullGroups: (value: boolean) => void
@@ -129,7 +129,7 @@ export const LfmProvider = ({ children }: { children: ReactNode }) => {
         useState<boolean>(false)
     const [indicateContentIDontOwn, setIndicateContentIDontOwn] =
         useState<boolean>(false)
-    const [ownedContent, setOwnedContent] = useState<string[] | null>(null)
+    const [ownedContent, setOwnedContent] = useState<string[]>([])
 
     // display:
     const [fontSize, setFontSize] = useState<number>(DEFAULT_BASE_FONT_SIZE)

--- a/src/hooks/useRenderLfm.ts
+++ b/src/hooks/useRenderLfm.ts
@@ -247,8 +247,8 @@ const useRenderLfm = ({ lfmSprite, context, raidView = false }: Props) => {
             } else {
                 timerNoteText = timerNoteTextOptions(false)
             }
-            let tip: string = null
-            if (!lfm.metadata.owned && indicateContentIDontOwn) {
+            let tip: string | null = null
+            if (lfm.metadata.owned == false && indicateContentIDontOwn) {
                 tip = `Requires "${lfm.quest?.required_adventure_pack}"`
             } else if (showQuestTips) {
                 tip = lfm.quest?.tip

--- a/src/hooks/useRenderLfm.ts
+++ b/src/hooks/useRenderLfm.ts
@@ -248,7 +248,7 @@ const useRenderLfm = ({ lfmSprite, context, raidView = false }: Props) => {
                 timerNoteText = timerNoteTextOptions(false)
             }
             let tip: string | null = null
-            if (lfm.metadata.owned === false && indicateContentIDontOwn) {
+            if (lfm.metadata?.owned === false && indicateContentIDontOwn) {
                 tip = `Requires "${lfm.quest?.required_adventure_pack}"`
             } else if (showQuestTips) {
                 tip = lfm.quest?.tip

--- a/src/hooks/useRenderLfm.ts
+++ b/src/hooks/useRenderLfm.ts
@@ -248,7 +248,7 @@ const useRenderLfm = ({ lfmSprite, context, raidView = false }: Props) => {
                 timerNoteText = timerNoteTextOptions(false)
             }
             let tip: string | null = null
-            if (lfm.metadata.owned == false && indicateContentIDontOwn) {
+            if (lfm.metadata.owned === false && indicateContentIDontOwn) {
                 tip = `Requires "${lfm.quest?.required_adventure_pack}"`
             } else if (showQuestTips) {
                 tip = lfm.quest?.tip

--- a/src/hooks/useRenderLfm.ts
+++ b/src/hooks/useRenderLfm.ts
@@ -21,7 +21,6 @@ import { convertMillisecondsToPrettyString } from "../utils/stringUtils.ts"
 import { SPRITE_MAP } from "../constants/spriteMap.ts"
 import { mapRaceAndGenderToRaceIconBoundingBox } from "../utils/socialUtils.ts"
 import { useQuestContext } from "../contexts/QuestContext.tsx"
-import { getActiveTimer } from "../utils/timerUtils.ts"
 
 interface Props {
     lfmSprite?: HTMLImageElement | null
@@ -42,6 +41,7 @@ const useRenderLfm = ({ lfmSprite, context, raidView = false }: Props) => {
         showIndicationForGroupsPostedByFriends,
         showIndicationForGroupsContainingFriends,
         highlightRaids,
+        indicateContentIDontOwn,
     } = useLfmContext()
     const { confineTextToBoundingBox } = useTextRenderer(context)
     const commonBoundingBoxes = useMemo(
@@ -247,6 +247,12 @@ const useRenderLfm = ({ lfmSprite, context, raidView = false }: Props) => {
             } else {
                 timerNoteText = timerNoteTextOptions(false)
             }
+            let tip: string = null
+            if (!lfm.metadata.owned && indicateContentIDontOwn) {
+                tip = `Requires "${lfm.quest?.required_adventure_pack}"`
+            } else if (showQuestTips) {
+                tip = lfm.quest?.tip
+            }
             const { boundingBox: timerNoteTextBoundingBox } =
                 confineTextToBoundingBox({
                     text: showTimerNote ? timerNoteText : "",
@@ -289,14 +295,14 @@ const useRenderLfm = ({ lfmSprite, context, raidView = false }: Props) => {
                 text: quest?.name || "Unknown Quest",
                 boundingBox: questPanelBoundingBoxWithPadding,
                 font: fonts.QUEST_NAME,
-                maxLines: showQuestTips && quest?.tip ? 1 : 2,
+                maxLines: tip ? 1 : 2,
                 centered: true,
             })
             const {
                 textLines: questTipTextLines,
                 boundingBox: questTipBoundingBox,
             } = confineTextToBoundingBox({
-                text: quest?.tip,
+                text: tip,
                 boundingBox: questPanelBoundingBoxWithPadding,
                 font: fonts.COMMENT,
                 maxLines: 1,
@@ -347,7 +353,7 @@ const useRenderLfm = ({ lfmSprite, context, raidView = false }: Props) => {
                 questTipBoundingBox,
                 questDifficultyBoundingBox,
                 questPanelBoundingBox,
-                hasTip: !!quest?.tip,
+                hasTip: tip != undefined,
             })
             questNameBoundingBox.y = questNameBoundingBoxY
             questTipBoundingBox.y = questTipBoundingBoxY
@@ -605,8 +611,20 @@ const useRenderLfm = ({ lfmSprite, context, raidView = false }: Props) => {
                             questNameLineHeight / 2
                     )
                 })
+
+                // quest difficulty
+                context.font = fonts.COMMENT
+                context.fillText(
+                    questDifficultyTextLines[0] || "",
+                    questDifficultyBoundingBox.centerX(),
+                    questDifficultyBoundingBox.centerY()
+                )
+
                 // quest tip
-                if (quest.tip && showQuestTip) {
+                if (tip) {
+                    if (!lfm.metadata.owned && indicateContentIDontOwn) {
+                        context.fillStyle = LFM_COLORS.NOT_OWNED
+                    }
                     context.font = fonts.TIP
                     questTipTextLines.forEach((line) => {
                         context.fillText(
@@ -616,14 +634,6 @@ const useRenderLfm = ({ lfmSprite, context, raidView = false }: Props) => {
                         )
                     })
                 }
-
-                // quest difficulty
-                context.font = fonts.COMMENT
-                context.fillText(
-                    questDifficultyTextLines[0] || "",
-                    questDifficultyBoundingBox.centerX(),
-                    questDifficultyBoundingBox.centerY()
-                )
 
                 // raid timer icon
                 const showRaidTimerIcon =
@@ -810,6 +820,7 @@ const useRenderLfm = ({ lfmSprite, context, raidView = false }: Props) => {
             calculateQuestInfoYPositions,
             highlightRaids,
             quests,
+            indicateContentIDontOwn,
         ]
     )
 

--- a/src/hooks/useRenderLfmOverlay.ts
+++ b/src/hooks/useRenderLfmOverlay.ts
@@ -1026,7 +1026,7 @@ const useRenderLfmOverlay = ({ lfmSprite, context }: Props) => {
 
                         if (quest.required_adventure_pack) {
                             renderQuestInfo(
-                                "Pack",
+                                "Pack:",
                                 quest.required_adventure_pack
                             )
                         }

--- a/src/models/Lfm.ts
+++ b/src/models/Lfm.ts
@@ -88,6 +88,8 @@ interface Lfm {
         raidActivity?: ActivityEvent[]
         isPostedByFriend?: boolean
         includesFriend?: boolean
+        owned?: boolean
+        isFull?: boolean
     }
 }
 


### PR DESCRIPTION
Ability to select the content you own and filter the LFM panel based on that. Also adds the ability to hide full groups.

Addresses https://github.com/Clemeit/ddo-audit-ui/issues/41 and https://github.com/Clemeit/ddo-audit-ui/issues/42